### PR TITLE
Enables IP Ban

### DIFF
--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -19,6 +19,7 @@ config:
 
 # https://home-assistant.io/components/http
 http:
+  ip_ban_enabled: true
   login_attempts_threshold: 20
 
 lovelace:


### PR DESCRIPTION
Hi George!

Thanks for your config, I'm using this as basis for my own config and it's been very helpful. I found out an issue with your `http` config: According to [the docs](https://www.home-assistant.io/integrations/http/#login_attempts_threshold), `login_attempts_threshold` only works if `ip_ban_enabled` is set to `true`, and it is `false` by default.

Since your only setting for `http` was this, I though to send this fix, otherwise it seems it won't work (at least on newer versions).